### PR TITLE
Added option to disable path check on parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const parse = (input, options = {}) => {
   let filepath = options.path;
 
   if (isParsed(input)) return input;
-  if (isValidPath(input) && fs.existsSync(input)) {
+  if (!(options.disablePathCheck || false) && isValidPath(input) && fs.existsSync(input)) {
     filepath = input;
     input = fs.readFileSync(input);
   }

--- a/test/test.js
+++ b/test/test.js
@@ -46,4 +46,12 @@ describe('gitignore', () => {
     const name = '_gitignore_multiline_comments';
     assert.equal(parse.format(fixture(name)), fixture(name));
   });
+
+  it('should not try to load ignored files as an ignorefile', () => {
+    // if our ignore only includes a relative file that happens to be valid (e.g. package.json)
+    const content = 'package.json';
+    // it should not path check (otherwise would fail)
+    const parsed = parse(content, { disablePathCheck: true });
+    assert.equal(parsed.patterns, content);
+  });
 });


### PR DESCRIPTION
Closes https://github.com/jonschlinkert/parse-gitignore/issues/12

See issue for more details. Added a test that will pass when `mocha` but only if the option is specified.